### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Copy README files
+        run: |
+          cp README.md docs/README.md
+          cp README_en.md docs/README_en.md
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./_site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,4 @@
 layout: default
 ---
 
-{% include_relative ../README.md %}
+{% include_relative README.md %}


### PR DESCRIPTION
## Summary
- build docs using GitHub Actions
- copy `README.md` and `README_en.md` into `docs` for the Jekyll build
- update `docs/index.md` to reference the copied README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `black --check markitdown` *(fails: would reformat files)*
- `ruff check markitdown` *(fails: found unused import)*

------
https://chatgpt.com/codex/tasks/task_b_686ed60074a883308c96eedb9a28640d