### PR TITLE
Fix Jekyll build for GitHub Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+# Specify Jekyll version to match GitHub Pages
+gem 'jekyll', '~> 4.3'
+
+group :jekyll_plugins do
+  gem 'jekyll-readme-index'
+end


### PR DESCRIPTION
## Summary
- support GitHub Pages build by bundling required Jekyll plugin

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'markitdown')*

------
https://chatgpt.com/codex/tasks/task_b_686ef566d6a4833082dd8a03f220da78