### PR TITLE
Fix GitHub Pages build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ htmlcov/
 !README.md
 !CONTRIBUTING.md
 !docs/**
+docs/README.md
 
 # Temporary files
 *.tmp

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,4 @@
 layout: default
 ---
 
-{% include_relative ../README.md %}
+{% include_relative README.md %}


### PR DESCRIPTION
## Summary
- remove docs/README from repo
- ignore docs/README so it isn't committed
- rely on workflow step to copy README during build

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_686ef851fb9c8330970cbd42b7fac3f5