### PR TITLE
Fix README to match actual CLI functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,7 @@ uv pip install -e .
 uv sync
 
 # ビルド実行
-pyinstaller --onefile wrapper.py \
-  --name ixv-util-markitdown.exe \
-  --icon resources/app.ico \
-  --add-data "templates;templates"
+pyinstaller --onefile wrapper.py --name ixv-util-markitdown.exe
 ```
 
 - 出力：`dist/ixv-util-markitdown.exe`
@@ -176,8 +173,8 @@ src/
 └── cli.py              # メインのCLI実装
     ├── choose_mode()    # モード選択プロンプト
     ├── run_markitdown() # MarkItDownモードの実行
-    ├── extract_text()   # NoMarkItDownモードのテキスト抽出
-    ├── convert_file()   # NoMarkItDownモードのファイル変換
+    ├── run_nomarkitdown()   # NoMarkItDownモードの実行
+    ├── process_files()   # ファイル処理共通ロジック
     └── main()          # CLI エントリーポイント
 ```
 

--- a/README_en.md
+++ b/README_en.md
@@ -124,10 +124,7 @@ uv pip install -e .
 uv pip install pyinstaller
 
 # Build
-pyinstaller --onefile wrapper.py \
-  --name ixv-util-markitdown.exe \
-  --icon resources/app.ico \
-  --add-data "templates;templates"
+pyinstaller --onefile wrapper.py --name ixv-util-markitdown.exe
 ```
 
 - Output: `dist/ixv-util-markitdown.exe`
@@ -169,8 +166,8 @@ src/
 └── cli.py              # Main CLI implementation
     ├── choose_mode()    # Mode selection prompt
     ├── run_markitdown() # Execute MarkItDown mode
-    ├── extract_text()   # Text extraction for NoMarkItDown mode
-    ├── convert_file()   # File conversion for NoMarkItDown mode
+    ├── run_nomarkitdown()   # Execute NoMarkItDown mode
+    ├── process_files()   # Common file processing logic
     └── main()           # CLI entry point
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,10 +130,7 @@ uv pip install -e .
 uv sync
 
 # ビルド実行
-pyinstaller --onefile wrapper.py \
-  --name ixv-util-markitdown.exe \
-  --icon resources/app.ico \
-  --add-data "templates;templates"
+pyinstaller --onefile wrapper.py --name ixv-util-markitdown.exe
 ```
 
 - 出力：`dist/ixv-util-markitdown.exe`
@@ -176,8 +173,8 @@ src/
 └── cli.py              # メインのCLI実装
     ├── choose_mode()    # モード選択プロンプト
     ├── run_markitdown() # MarkItDownモードの実行
-    ├── extract_text()   # NoMarkItDownモードのテキスト抽出
-    ├── convert_file()   # NoMarkItDownモードのファイル変換
+    ├── run_nomarkitdown()   # NoMarkItDownモードの実行
+    ├── process_files()   # ファイル処理共通ロジック
     └── main()          # CLI エントリーポイント
 ```
 


### PR DESCRIPTION
## Summary
- update README files to reflect current CLI implementation
- remove PyInstaller options for missing resources
- keep docs in sync

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'markitdown')*

------
https://chatgpt.com/codex/tasks/task_b_687e35cd4220833092d18e70cd783aef