### PR TITLE
docs: clarify MarkItDown mode input formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img width="1745" height="684" alt="ixv-util" src="https://github.com/user-attachments/assets/b4cca023-74f7-4068-897f-4558690fdbdd" />
 
 
-IXV-util-MarkItDown は、Microsoft MarkItDown をベースにした `.docx` → Markdown 変換ツールを、Windows の単一実行ファイル（`.exe`）および macOS アプリケーション（`.app`）としてバンドルしたクロスプラットフォーム CLI ユーティリティです
+IXV-util-MarkItDown は、Microsoft MarkItDown をベースにした Markdown 変換ツールを、Windows の単一実行ファイル（`.exe`）および macOS アプリケーション（`.app`）としてバンドルしたクロスプラットフォーム CLI ユーティリティです。MarkItDown モードでは `.docx` に限らず、MarkItDown ライブラリがサポートする PDF などのファイル形式も Markdown に変換できます。
 
 ---
 
@@ -45,7 +45,7 @@ Markdownは、プレーンテキストに非常に近く、最小限のマーク
 
 1. **MarkItDown モード**: Microsoft MarkItDown の完全な機能を使用
    - 画像、表、リスト、数式などの高度な変換に対応
-   - より多くのファイル形式をサポート
+   - 拡張子チェックを行わず、MarkItDown ライブラリがサポートする PDF や PPTX などのファイル形式を処理
 
 2. **NoMarkItDown モード**: シンプルな独自実装
    - `.docx` ファイルからの基本的なテキスト抽出のみ（他の拡張子はエラー）
@@ -65,6 +65,7 @@ Markdownは、プレーンテキストに非常に近く、最小限のマーク
    ```bat
    ixv-util-markitdown input.docx -o output.md
    ```
+   *MarkItDown モードでは `input.pdf` など他形式も指定できます。*
 
 ### macOS
 
@@ -74,6 +75,7 @@ Markdownは、プレーンテキストに非常に近く、最小限のマーク
    ```bash
    ixv-util-markitdown input.docx -o output.md
    ```
+   *MarkItDown モードでは `input.pdf` など他形式も指定できます。*
 
 ---
 
@@ -94,6 +96,8 @@ ixv-util-markitdown inputs/*.docx -d outputs
 # 変換オプション一覧
 ixv-util-markitdown --help
 ```
+
+*MarkItDown モードでは `input.pdf` のように `.docx` 以外のファイルも指定できます。*
 
 - `-o, --output` : 出力ファイル名を指定
 - `-d, --directory` : 出力先ディレクトリを指定（存在しない場合は作成）

--- a/README_en.md
+++ b/README_en.md
@@ -1,6 +1,6 @@
 # IXV-util-MarkItDown
 
-IXV-util-MarkItDown bundles the Microsoft MarkItDown `.docx` to Markdown converter into a cross-platform CLI utility available as a standalone executable (`.exe`) for Windows and an application (`.app`) for macOS.
+IXV-util-MarkItDown bundles Microsoft MarkItDown into a cross-platform CLI utility available as a standalone executable (`.exe`) for Windows and an application (`.app`) for macOS. In MarkItDown mode it accepts not only `.docx` but also other formats supported by the library, such as PDF, and converts them to Markdown.
 
 ---
 
@@ -39,7 +39,7 @@ The tool has two modes:
 
 1. **MarkItDown mode**: Uses the full Microsoft MarkItDown functionality.
    - Supports advanced conversion of images, tables, lists, formulas, and more.
-   - Handles more file formats.
+   - Does not check file extensions and can handle any format supported by MarkItDown, such as PDF or PPTX.
 
 2. **NoMarkItDown mode**: Simple built-in implementation.
    - Extracts only basic text.
@@ -59,6 +59,7 @@ You choose which mode to use when launching the program.
    ```bat
    ixv-util-markitdown input.docx -o output.md
    ```
+   *In MarkItDown mode you may also specify other formats like `input.pdf`.*
 
 ### macOS
 
@@ -68,6 +69,7 @@ You choose which mode to use when launching the program.
    ```bash
    ixv-util-markitdown input.docx -o output.md
    ```
+   *In MarkItDown mode you may also specify other formats like `input.pdf`.*
 
 ---
 
@@ -85,6 +87,8 @@ ixv-util-markitdown *.docx -d docs/markdown
 # List options
 ixv-util-markitdown --help
 ```
+
+*MarkItDown mode also accepts non-`.docx` files such as `input.pdf`.*
 
 - `-o, --output` : Specify the output file name.
 - `-d, --directory` : Specify the output directory (creates it if it doesn't exist).


### PR DESCRIPTION
## Summary
- clarify that MarkItDown mode accepts any format supported by MarkItDown, not only `.docx`
- mirror the note in both Japanese and English README versions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'markitdown')*

------
https://chatgpt.com/codex/tasks/task_b_688f5f657b3883308da8415c1a943db0