### PR TITLE
Embed base64 images in markdown using keep_data_uris=True

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -56,9 +56,9 @@ def write_output(content, output_path):
 
 
 def run_markitdown(input_path):
-    """Convert file using MarkItDown."""
+    """Convert file using MarkItDown with base64 image embedding."""
     md = MarkItDown()
-    result = md.convert(str(input_path))
+    result = md.convert(str(input_path), keep_data_uris=True)
     return result.text_content
 
 


### PR DESCRIPTION
## Summary
This PR implements a simple and effective solution for embedding images directly in markdown output using MarkItDown's `keep_data_uris=True` parameter.

## Changes
- ✅ **Single line change**: Add `keep_data_uris=True` parameter to `md.convert()` method
- ✅ **Self-contained output**: Images are embedded as base64 data URIs
- ✅ **Portable markdown**: No external image files needed
- ✅ **Environment independent**: Works across all systems

## Key Benefits
- **Simplicity**: Minimal code change (1 line modified)
- **Portability**: Single file contains everything
- **Reliability**: No broken image links or missing files
- **Compatibility**: Uses MarkItDown's built-in functionality

## Testing
- ✅ Tested with `tests/inputs/doc_with_image.docx`
- ✅ Generates 32KB+ markdown with complete base64 image data
- ✅ Output format: `\![alt](data:image/png;base64,iVBORw0...)`

## Technical Details
```python
# Before
result = md.convert(str(input_path))

# After  
result = md.convert(str(input_path), keep_data_uris=True)
```

This approach supersedes the complex attachment handling attempted in PR #23, providing a cleaner and more reliable solution.

🤖 Generated with [Claude Code](https://claude.ai/code)