### PR TITLE
feat: マークダウンの埋め込み画像を画像ファイルとして保存する機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,52 @@ ixv-util-markitdown input.docx --mode nomarkitdown
 - `--mode` : 非対話モードで動作モードを指定（`markitdown` または `nomarkitdown`）
 - `-o, --output` : 出力ファイル名を指定
 - `-d, --directory` : 出力先ディレクトリを指定（存在しない場合は作成）
+- `--no-save-images` : 画像をbase64データURIとしてマークダウンに埋め込み（デフォルト：画像ファイルとして保存）
 - `-v, --version` : バージョン表示
 - `-h, --help`    : ヘルプ表示
+
+### 画像の取り扱い
+
+**MarkItDown モード**では、文書に含まれる画像を以下の2つの方法で処理できます：
+
+#### 1. 画像ファイル保存モード（デフォルト）
+```bash
+# 画像を個別ファイルとして保存（推奨）
+ixv-util-markitdown document.docx -o output.md
+```
+
+- 画像は `{出力ファイル名}_images/` ディレクトリに保存されます
+- ファイル名は `image1.png`, `image2.jpg` のように連番で命名されます
+- マークダウンからは相対パスで参照：`![alt text](output_images/image1.png)`
+- **メリット**：マークダウンファイルのサイズが小さく、可読性が向上
+
+#### 2. base64埋め込みモード
+```bash
+# 画像をbase64データとしてマークダウンに埋め込み
+ixv-util-markitdown document.docx -o output.md --no-save-images
+```
+
+- 画像データがbase64形式でマークダウンに直接埋め込まれます
+- 単一ファイルで完結するため、ファイル共有が簡単
+- **注意**：ファイルサイズが大きくなり、テキストエディタでの編集が困難
+
+#### 複数ファイル処理時の画像管理
+```bash
+# 複数ファイルを一括変換
+ixv-util-markitdown *.docx -d outputs
+```
+
+各ファイルごとに独立した画像ディレクトリが作成されるため、画像ファイル名の競合は発生しません：
+```
+outputs/
+├── document1.md
+├── document1_images/
+│   ├── image1.png
+│   └── image2.jpg
+├── document2.md
+└── document2_images/
+    └── image1.png
+```
 
 ---
 

--- a/README_en.md
+++ b/README_en.md
@@ -92,8 +92,52 @@ ixv-util-markitdown --help
 
 - `-o, --output` : Specify the output file name.
 - `-d, --directory` : Specify the output directory (creates it if it doesn't exist).
+- `--no-save-images` : Embed images as base64 data URIs in markdown (default: save as separate files).
 - `-v, --version` : Display version.
 - `-h, --help`    : Show help.
+
+### Image Handling
+
+In **MarkItDown mode**, images contained in documents can be processed in two ways:
+
+#### 1. Image File Saving Mode (Default)
+```bash
+# Save images as separate files (recommended)
+ixv-util-markitdown document.docx -o output.md
+```
+
+- Images are saved to a `{output_filename}_images/` directory
+- Files are named sequentially: `image1.png`, `image2.jpg`, etc.
+- Referenced from markdown with relative paths: `![alt text](output_images/image1.png)`
+- **Benefits**: Smaller markdown file size and improved readability
+
+#### 2. Base64 Embedding Mode
+```bash
+# Embed images as base64 data in markdown
+ixv-util-markitdown document.docx -o output.md --no-save-images
+```
+
+- Image data is directly embedded in markdown as base64 format
+- Self-contained single file makes sharing easier
+- **Note**: Results in larger file sizes and difficult text editor handling
+
+#### Image Management for Multiple Files
+```bash
+# Batch convert multiple files
+ixv-util-markitdown *.docx -d outputs
+```
+
+Independent image directories are created for each file, preventing filename conflicts:
+```
+outputs/
+├── document1.md
+├── document1_images/
+│   ├── image1.png
+│   └── image2.jpg
+├── document2.md
+└── document2_images/
+    └── image1.png
+```
 
 ---
 

--- a/scripts/IXV-util-MarkItDown-mac.spec
+++ b/scripts/IXV-util-MarkItDown-mac.spec
@@ -25,13 +25,14 @@ site_packages = Path(get_site_packages())
 
 a = Analysis(
     [str(project_root / 'src/cli.py')],
-    pathex=[str(project_root)],
+    pathex=[str(project_root), str(project_root / 'src')],
     binaries=[],
     datas=[
         (str(site_packages / 'magika/models'), 'magika/models'),
         (str(site_packages / 'magika/config'), 'magika/config'),
+        (str(project_root / 'src/image_extractor.py'), '.'),
     ],
-    hiddenimports=[],
+    hiddenimports=['image_extractor'],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/src/cli.py
+++ b/src/cli.py
@@ -34,32 +34,11 @@ def parse_args(argv):
     parser.add_argument("-d", "--directory", help="Output directory")
     parser.add_argument("-v", "--version", action="version", version=__version__)
     
-    # Mode selection options
-    mode_group = parser.add_mutually_exclusive_group()
-    mode_group.add_argument(
-        "--markitdown", 
-        action="store_true", 
-        default=True,
-        help="Use MarkItDown converter (default)"
-    )
-    mode_group.add_argument(
-        "--nomarkitdown", 
-        action="store_true", 
-        help="Use simple NoMarkItDown converter (docx only)"
-    )
-    
     # Image handling options
-    image_group = parser.add_mutually_exclusive_group()
-    image_group.add_argument(
-        "--save-images", 
-        action="store_true", 
-        default=True,
-        help="Save images as separate files (default)"
-    )
-    image_group.add_argument(
+    parser.add_argument(
         "--no-save-images", 
         action="store_true", 
-        help="Keep images as base64 data URIs in markdown"
+        help="Keep images as base64 data URIs in markdown (default: save as separate files)"
     )
     
     args = parser.parse_args(argv)
@@ -152,21 +131,13 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
+    choice = choose_mode()
     args = parse_args(argv)
     
-    # Determine mode from arguments or interactive choice
-    if args.nomarkitdown:
-        process_files(args, run_nomarkitdown)
-    elif args.markitdown or len(argv) > 0:
-        # If arguments provided or explicitly markitdown, use markitdown
+    if choice == "1":
         process_files(args, run_markitdown)
     else:
-        # Interactive mode
-        choice = choose_mode()
-        if choice == "1":
-            process_files(args, run_markitdown)
-        else:
-            process_files(args, run_nomarkitdown)
+        process_files(args, run_nomarkitdown)
 
 
 if __name__ == "__main__":

--- a/src/cli.py
+++ b/src/cli.py
@@ -9,6 +9,10 @@ except ImportError:  # pragma: no cover - fallback for isolated execution
 import zipfile
 import xml.etree.ElementTree as ET
 from markitdown import MarkItDown
+try:
+    from .image_extractor import extract_and_save_images, count_base64_images
+except ImportError:
+    from image_extractor import extract_and_save_images, count_base64_images
 
 
 def choose_mode() -> str:
@@ -29,6 +33,35 @@ def parse_args(argv):
     parser.add_argument("-o", "--output", help="Output file name (single input only)")
     parser.add_argument("-d", "--directory", help="Output directory")
     parser.add_argument("-v", "--version", action="version", version=__version__)
+    
+    # Mode selection options
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--markitdown", 
+        action="store_true", 
+        default=True,
+        help="Use MarkItDown converter (default)"
+    )
+    mode_group.add_argument(
+        "--nomarkitdown", 
+        action="store_true", 
+        help="Use simple NoMarkItDown converter (docx only)"
+    )
+    
+    # Image handling options
+    image_group = parser.add_mutually_exclusive_group()
+    image_group.add_argument(
+        "--save-images", 
+        action="store_true", 
+        default=True,
+        help="Save images as separate files (default)"
+    )
+    image_group.add_argument(
+        "--no-save-images", 
+        action="store_true", 
+        help="Keep images as base64 data URIs in markdown"
+    )
+    
     args = parser.parse_args(argv)
 
     if args.output and len(args.files) > 1:
@@ -55,11 +88,24 @@ def write_output(content, output_path):
         f.write(content)
 
 
-def run_markitdown(input_path):
-    """Convert file using MarkItDown with base64 image embedding."""
+def run_markitdown(input_path, save_images=True, output_path=None):
+    """Convert file using MarkItDown with configurable image handling."""
     md = MarkItDown()
-    result = md.convert(str(input_path), keep_data_uris=True)
-    return result.text_content
+    
+    if save_images:
+        # Convert with base64 images first, then extract and save them
+        result = md.convert(str(input_path), keep_data_uris=True)
+        content = result.text_content
+        
+        if output_path and count_base64_images(content) > 0:
+            content = extract_and_save_images(content, output_path)
+            print(f"Extracted and saved {count_base64_images(result.text_content)} images to {os.path.splitext(os.path.basename(output_path))[0]}_images/")
+        
+        return content
+    else:
+        # Keep base64 images embedded
+        result = md.convert(str(input_path), keep_data_uris=True)
+        return result.text_content
 
 
 def run_nomarkitdown(input_path):
@@ -85,10 +131,17 @@ def process_files(args, converter_func):
     if args.directory:
         os.makedirs(args.directory, exist_ok=True)
 
+    save_images = not args.no_save_images
+
     for input_path in args.files:
         try:
-            content = converter_func(input_path)
             output_path = get_output_path(input_path, args)
+            
+            if converter_func == run_markitdown:
+                content = converter_func(input_path, save_images=save_images, output_path=output_path)
+            else:
+                content = converter_func(input_path)
+                
             write_output(content, output_path)
             print(f"Converted: {input_path} -> {output_path}")
         except Exception as e:
@@ -99,13 +152,21 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
-    choice = choose_mode()
     args = parse_args(argv)
     
-    if choice == "1":
+    # Determine mode from arguments or interactive choice
+    if args.nomarkitdown:
+        process_files(args, run_nomarkitdown)
+    elif args.markitdown or len(argv) > 0:
+        # If arguments provided or explicitly markitdown, use markitdown
         process_files(args, run_markitdown)
     else:
-        process_files(args, run_nomarkitdown)
+        # Interactive mode
+        choice = choose_mode()
+        if choice == "1":
+            process_files(args, run_markitdown)
+        else:
+            process_files(args, run_nomarkitdown)
 
 
 if __name__ == "__main__":

--- a/src/image_extractor.py
+++ b/src/image_extractor.py
@@ -1,0 +1,101 @@
+import os
+import re
+import base64
+from typing import Dict, Tuple
+
+
+def extract_and_save_images(markdown_content: str, output_file_path: str) -> str:
+    """
+    Extract base64 images from markdown content and save them as files.
+    
+    Args:
+        markdown_content: Markdown content containing base64 images
+        output_file_path: Path to the output markdown file
+        
+    Returns:
+        Modified markdown content with image links replaced
+    """
+    # Create images directory
+    base_name = os.path.splitext(os.path.basename(output_file_path))[0]
+    images_dir = os.path.join(os.path.dirname(output_file_path), f"{base_name}_images")
+    
+    # Pattern to match markdown images with data URI
+    pattern = r'!\[([^\]]*)\]\(data:([^;]+);base64,([^)]+)\)'
+    
+    image_counter = 1
+    
+    def replace_image(match):
+        nonlocal image_counter
+        
+        alt_text = match.group(1)
+        mime_type = match.group(2)
+        base64_data = match.group(3)
+        
+        # Determine file extension from MIME type
+        extension = _get_extension_from_mime_type(mime_type)
+        
+        # Generate unique filename
+        filename = f"image{image_counter}{extension}"
+        image_counter += 1
+        
+        # Ensure images directory exists
+        if not os.path.exists(images_dir):
+            os.makedirs(images_dir, exist_ok=True)
+        
+        # Save image file
+        image_path = os.path.join(images_dir, filename)
+        try:
+            with open(image_path, 'wb') as f:
+                f.write(base64.b64decode(base64_data))
+        except Exception as e:
+            print(f"Warning: Failed to save image {filename}: {e}")
+            # Return original data URI if saving fails
+            return match.group(0)
+        
+        # Return relative path link
+        relative_image_path = os.path.join(f"{base_name}_images", filename)
+        return f"![{alt_text}]({relative_image_path})"
+    
+    # Replace all base64 images with file links
+    modified_content = re.sub(pattern, replace_image, markdown_content)
+    
+    return modified_content
+
+
+def _get_extension_from_mime_type(mime_type: str) -> str:
+    """
+    Get file extension from MIME type.
+    
+    Args:
+        mime_type: MIME type string (e.g., 'image/png')
+        
+    Returns:
+        File extension with dot (e.g., '.png')
+    """
+    mime_to_ext = {
+        'image/png': '.png',
+        'image/jpeg': '.jpg',
+        'image/jpg': '.jpg',
+        'image/gif': '.gif',
+        'image/bmp': '.bmp',
+        'image/webp': '.webp',
+        'image/svg+xml': '.svg',
+        'image/tiff': '.tiff',
+        'image/x-icon': '.ico',
+    }
+    
+    return mime_to_ext.get(mime_type.lower(), '.png')
+
+
+def count_base64_images(markdown_content: str) -> int:
+    """
+    Count the number of base64 images in markdown content.
+    
+    Args:
+        markdown_content: Markdown content to analyze
+        
+    Returns:
+        Number of base64 images found
+    """
+    pattern = r'!\[([^\]]*)\]\(data:([^;]+);base64,([^)]+)\)'
+    return len(re.findall(pattern, markdown_content))


### PR DESCRIPTION
## Summary
- Issue #28 で要求された画像ファイル保存機能を実装
- base64画像データをファイルとして保存し、マークダウンから相対パスで参照
- マークダウンファイルの可読性を大幅に向上
- **既存のCLI動作を完全に維持**

## 実装内容
### 新機能
- `src/image_extractor.py`: base64画像の抽出・保存機能
- `--no-save-images` オプション: base64埋め込みを維持（オプトアウト方式）
- デフォルト動作: 画像を個別ファイルとして保存

### 画像保存仕様
- 出力ディレクトリ: `{出力ファイル名}_images/`
- ファイル名形式: `image1.png`, `image2.png`, ...
- MIMEタイプから自動拡張子判定
- 複数ファイル処理時の競合回避

### 既存機能との互換性
- ✅ インタラクティブモード選択を完全に維持
- ✅ 既存のCLIオプション（`-o`, `-d`, `-v`）は変更なし
- ✅ NoMarkItDownモードは変更なし
- ✅ 直接実行(`uv run src/cli.py`)とモジュール実行(`uv run python -m src.cli`)の両方に対応

## 変更されたファイル
- `src/cli.py`: 画像保存機能の統合（最小限の変更）
- `src/image_extractor.py`: 新規追加

## Test plan
- [x] 単一ファイルでの画像抽出・保存テスト
- [x] 複数ファイルでの画像ディレクトリ分離テスト
- [x] `--no-save-images`でのbase64埋め込み維持テスト
- [x] ディレクトリ出力(`-d`)との組み合わせテスト
- [x] インタラクティブモードの動作確認
- [x] 直接実行での相対インポート対応テスト

🤖 Generated with [Claude Code](https://claude.ai/code)