### PR TITLE
CLIに非対話モードの--modeオプションを追加

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -90,6 +90,20 @@ ixv-util-markitdown --help
 
 *MarkItDown mode also accepts non-`.docx` files such as `input.pdf`.*
 
+### Non-interactive mode
+
+Use the `--mode` option to skip the mode selection prompt.
+
+```bash
+# Run in MarkItDown mode
+ixv-util-markitdown input.docx --mode markitdown
+
+# Run in NoMarkItDown mode
+ixv-util-markitdown input.docx --mode nomarkitdown
+```
+
+- `--mode` : Specify operation mode non-interactively (`markitdown` or `nomarkitdown`).
+
 - `-o, --output` : Specify the output file name.
 - `-d, --directory` : Specify the output directory (creates it if it doesn't exist).
 - `--no-save-images` : Embed images as base64 data URIs in markdown (default: save as separate files).

--- a/src/cli.py
+++ b/src/cli.py
@@ -33,6 +33,13 @@ def parse_args(argv):
     parser.add_argument("-o", "--output", help="Output file name (single input only)")
     parser.add_argument("-d", "--directory", help="Output directory")
     parser.add_argument("-v", "--version", action="version", version=__version__)
+
+    # Mode selection option
+    parser.add_argument(
+        "--mode",
+        choices=["markitdown", "nomarkitdown"],
+        help="Select mode non-interactively (markitdown or nomarkitdown)",
+    )
     
     # Image handling options
     parser.add_argument(
@@ -131,10 +138,15 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
-    choice = choose_mode()
     args = parse_args(argv)
-    
-    if choice == "1":
+
+    if args.mode:
+        mode = args.mode
+    else:
+        choice = choose_mode()
+        mode = "markitdown" if choice == "1" else "nomarkitdown"
+
+    if mode == "markitdown":
         process_files(args, run_markitdown)
     else:
         process_files(args, run_nomarkitdown)


### PR DESCRIPTION
## 概要
- CLIで`--mode`オプションを受け付け、MarkItDown/NoMarkItDownモードを非対話で選択可能に
- 英語版READMEに`--mode`の説明を追加

## テスト
- `pytest`（依存ライブラリ`markitdown`の未インストールにより失敗）
- `pip install -e upstream/packages/markitdown`（`hatchling`が取得できず失敗）

------
https://chatgpt.com/codex/tasks/task_b_6890c4b9ca1883308a25989702c17eb5