### PR TITLE
Fix macOS build to generate single executable instead of .app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ uv.lock
 .coverage
 htmlcov/
 inputs/
+outputs/
 
 # Output files
 *.md

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ ixv-util-markitdown --help
 ```
 
 *MarkItDown モードでは `input.pdf` のように `.docx` 以外のファイルも指定できます。*
+
 ### 非対話モード
 
 `--mode` オプションを指定するとモード選択のプロンプトをスキップできます。
@@ -109,7 +110,6 @@ ixv-util-markitdown input.docx --mode markitdown
 # NoMarkItDown モードで実行
 ixv-util-markitdown input.docx --mode nomarkitdown
 ```
-
 
 - `--mode` : 非対話モードで動作モードを指定（`markitdown` または `nomarkitdown`）
 - `-o, --output` : 出力ファイル名を指定

--- a/README.md
+++ b/README.md
@@ -53,6 +53,27 @@ Markdownは、プレーンテキストに非常に近く、最小限のマーク
 
 プログラムを起動すると、どちらのモードを使用するか選択できます。
 
+## 対応ファイル形式
+
+MarkItDown モードでは、以下のファイル形式を Markdown に変換できます：
+
+- Word: `.docx`
+- PDF: `.pdf`
+- PowerPoint: `.pptx`
+- Excel: `.xlsx`, `.xls`
+- CSV: `.csv`
+- プレーンテキスト/マークダウン/JSON: `.txt`, `.text`, `.md`, `.markdown`, `.json`, `.jsonl`
+- 画像: `.jpg`, `.jpeg`, `.png`
+- 音声/動画: `.wav`, `.mp3`, `.m4a`, `.mp4`
+- Jupyter Notebook: `.ipynb`
+- 電子書籍: `.epub`
+- Outlook メール: `.msg`
+- アーカイブ: `.zip`
+- HTML ページやウェブサイト（YouTube、Wikipedia、Bing 検索結果など）
+- RSS/Atom/汎用 XML: `.rss`, `.atom`, `.xml`
+
+NoMarkItDown モードは `.docx` のみ対応です。
+
 ---
 
 ## インストール
@@ -69,9 +90,16 @@ Markdownは、プレーンテキストに非常に近く、最小限のマーク
 
 ### macOS
 
-1. [Releases](https://github.com/elvezjp/IXV-util-MarkItDown/releases) から `IXV-util-MarkItDown-<version>.dmg` をダウンロード
-2. DMG をマウントし、`Applications` フォルダにドラッグ＆ドロップ
-3. ターミナルで以下を実行
+1. [Releases](https://github.com/elvezjp/IXV-util-MarkItDown/releases) から最新版の `ixv-util-markitdown-<version>-mac` をダウンロード
+2. 任意のフォルダに配置し、実行権限を付与
+   ```bash
+   chmod +x ixv-util-markitdown-<version>-mac
+   ```
+3. 必要であれば PATH 環境変数に追加するか、`/usr/local/bin` にシンボリックリンクを作成
+   ```bash
+   ln -s /path/to/ixv-util-markitdown-<version>-mac /usr/local/bin/ixv-util-markitdown
+   ```
+4. ターミナルで以下を実行
    ```bash
    ixv-util-markitdown input.docx -o output.md
    ```
@@ -198,7 +226,7 @@ pyinstaller --onefile wrapper.py --name ixv-util-markitdown.exe
 
 - 出力：`dist/ixv-util-markitdown.exe`
 
-### macOS 用 `.app` のビルド
+### macOS 用単一実行ファイルのビルド
 
 ```bash
 # PyInstallerをインストール（dev-dependenciesに含まれています）
@@ -208,7 +236,7 @@ uv sync
 uv run pyinstaller scripts/IXV-util-MarkItDown-mac.spec
 ```
 
-- 出力：`dist/IXV-util-MarkItDown.app`
+- 出力：`dist/ixv-util-markitdown`
 - 注意：markitdownライブラリの依存関係を適切に同梱するため、必ず`scripts/IXV-util-MarkItDown-mac.spec`を使用してください
 
 ---

--- a/README_en.md
+++ b/README_en.md
@@ -47,6 +47,27 @@ The tool has two modes:
 
 You choose which mode to use when launching the program.
 
+## Supported File Formats
+
+MarkItDown mode can convert the following file formats to Markdown:
+
+- Word: `.docx`
+- PDF: `.pdf`
+- PowerPoint: `.pptx`
+- Excel: `.xlsx`, `.xls`
+- CSV: `.csv`
+- Plain text/Markdown/JSON: `.txt`, `.text`, `.md`, `.markdown`, `.json`, `.jsonl`
+- Images: `.jpg`, `.jpeg`, `.png`
+- Audio/Video: `.wav`, `.mp3`, `.m4a`, `.mp4`
+- Jupyter Notebook: `.ipynb`
+- E-books: `.epub`
+- Outlook emails: `.msg`
+- Archives: `.zip`
+- HTML pages and websites (YouTube, Wikipedia, Bing search results, etc.)
+- RSS/Atom/Generic XML: `.rss`, `.atom`, `.xml`
+
+NoMarkItDown mode only supports `.docx` files.
+
 ---
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,9 @@ name = "markitdown"
 console = true
 
 [tool.pyinstaller.macos]
-# macOS .appファイル作成用のPyInstaller設定
-script = "markitdown/cli.py"
-name = "MarkItDown"
-onedir = true
-windowed = true
+# macOS 単一実行ファイル作成用のPyInstaller設定
+entry-point = "wrapper.py"
+onefile = true
+name = "ixv-util-markitdown"
+console = true
 distpath = "./dist"

--- a/scripts/IXV-util-MarkItDown-mac.spec
+++ b/scripts/IXV-util-MarkItDown-mac.spec
@@ -24,7 +24,7 @@ def get_site_packages():
 site_packages = Path(get_site_packages())
 
 a = Analysis(
-    [str(project_root / 'src/cli.py')],
+    [str(project_root / 'wrapper.py')],
     pathex=[str(project_root), str(project_root / 'src')],
     binaries=[],
     datas=[
@@ -46,14 +46,17 @@ pyz = PYZ(a.pure)
 exe = EXE(
     pyz,
     a.scripts,
+    a.binaries,
+    a.datas,
     [],
-    exclude_binaries=True,
-    name='IXV-util-MarkItDown',
+    name='ixv-util-markitdown',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
-    console=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
     disable_windowed_traceback=False,
     argv_emulation=False,
     target_arch=None,
@@ -61,30 +64,4 @@ exe = EXE(
     entitlements_file=None,
 )
 
-coll = COLLECT(
-    exe,
-    a.binaries,
-    a.datas,
-    strip=False,
-    upx=True,
-    upx_exclude=[],
-    name='IXV-util-MarkItDown',
-)
-
-app = BUNDLE(
-    coll,
-    name='IXV-util-MarkItDown.app',
-    icon=None,
-    bundle_identifier='jp.elvez.ixv-util-markitdown',
-    info_plist={
-        'CFBundleDisplayName': 'IXV-util-MarkItDown',
-        'CFBundleExecutable': 'IXV-util-MarkItDown',
-        'CFBundleIdentifier': 'jp.elvez.ixv-util-markitdown',
-        'CFBundleName': 'IXV-util-MarkItDown',
-        'CFBundlePackageType': 'APPL',
-        'CFBundleShortVersionString': '0.1.0',
-        'CFBundleVersion': '0.1.0',
-        'LSMinimumSystemVersion': '10.15',
-        'NSHighResolutionCapable': True,
-    },
-)
+# 単一実行ファイルの場合、COLLECTとBUNDLEは不要


### PR DESCRIPTION
## Summary
- Changed macOS build configuration to generate single executable file instead of .app bundle
- Modified PyInstaller settings to create console application suitable for CLI usage
- Updated installation instructions in README.md

## Changes Made
- **pyproject.toml**: Updated macOS PyInstaller settings
  - Changed from `windowed=true` to `console=true` for CLI usage
  - Changed from `onedir=true` to `onefile=true` for single executable
  - Updated executable name to `ixv-util-markitdown` for consistency
- **scripts/IXV-util-MarkItDown-mac.spec**: Modified PyInstaller spec file
  - Removed BUNDLE and COLLECT steps (not needed for single executable)
  - Added binaries and data to EXE step for standalone executable
  - Set console=True for command line interface
- **README.md**: Updated macOS installation instructions
  - Changed from .dmg/.app installation to single executable download
  - Added instructions for setting execute permissions
  - Updated build documentation

## Test plan
- [ ] Build macOS executable using updated spec file
- [ ] Verify executable runs from command line without .app wrapper
- [ ] Test all CLI functionality works correctly
- [ ] Verify executable can be placed in PATH and run from anywhere

Fixes #29

🤖 Generated with [Claude Code](https://claude.ai/code)