### PR TITLE
Handle empty cells in Excel conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ IXV-util-MarkItDown側で`upstream/`ディレクトリ内のファイルを独�
    - 変更内容を文書化し、`docs/upstream-modifications.md`などに記録
    - 定期的に上流との差分を確認：`git diff markitdown-upstream/main HEAD -- upstream/`
 
+#### upstreamへの変更履歴
+
+- **2025-08-06**: ExcelファイルのXLSX/XLS変換時に空のセルが`NaN`として表示される問題を修正 (コミット: 9185bb7)
+  - `upstream/packages/markitdown/src/markitdown/converters/_xlsx_converter.py`を変更
+  - pandasの`to_html`メソッドに`na_rep=""`パラメータを追加
+
 ---
 
 ## 配布／アップデート

--- a/README_en.md
+++ b/README_en.md
@@ -334,6 +334,12 @@ If you have modified files under `upstream/` in this project, conflicts may aris
    - Periodically check differences with upstream:
      `git diff markitdown-upstream/main HEAD -- upstream/`
 
+#### Upstream modification history
+
+- **2025-08-06**: Fixed issue where empty cells in Excel XLSX/XLS files were displayed as `NaN` (commit: 9185bb7)
+  - Modified `upstream/packages/markitdown/src/markitdown/converters/_xlsx_converter.py`
+  - Added `na_rep=""` parameter to pandas `to_html` method
+
 ---
 
 ## Distribution / Updates

--- a/upstream/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
+++ b/upstream/packages/markitdown/src/markitdown/converters/_xlsx_converter.py
@@ -84,7 +84,7 @@ class XlsxConverter(DocumentConverter):
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
+            html_content = sheets[s].to_html(index=False, na_rep="")
             md_content += (
                 self._html_converter.convert_string(
                     html_content, **kwargs
@@ -146,7 +146,7 @@ class XlsConverter(DocumentConverter):
         md_content = ""
         for s in sheets:
             md_content += f"## {s}\n"
-            html_content = sheets[s].to_html(index=False)
+            html_content = sheets[s].to_html(index=False, na_rep="")
             md_content += (
                 self._html_converter.convert_string(
                     html_content, **kwargs

--- a/upstream/packages/markitdown/tests/test_excel_empty_cells.py
+++ b/upstream/packages/markitdown/tests/test_excel_empty_cells.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3 -m pytest
+import io
+import pytest
+
+# Skip the entire module if required dependencies are missing
+pandas = pytest.importorskip("pandas")
+pytest.importorskip("requests")
+
+from markitdown import MarkItDown, StreamInfo
+
+
+@pytest.mark.parametrize(
+    "extension,write_engine,read_dep",
+    [
+        (".xlsx", "openpyxl", "openpyxl"),
+        (".xls", "xlwt", "xlrd"),
+    ],
+)
+def test_excel_empty_cells_no_nan(extension, write_engine, read_dep):
+    pytest.importorskip(write_engine)
+    pytest.importorskip(read_dep)
+
+    df = pandas.DataFrame({"A": [1, None], "B": ["text", None]})
+
+    bio = io.BytesIO()
+    df.to_excel(bio, index=False, engine=write_engine)
+    bio.seek(0)
+
+    markitdown = MarkItDown()
+    result = markitdown.convert(bio, stream_info=StreamInfo(extension=extension))
+
+    assert "NaN" not in result.markdown


### PR DESCRIPTION
## Summary
- prevent `NaN` from appearing when converting XLSX/XLS sheets by supplying `na_rep=""` to pandas `to_html`
- add regression test ensuring empty Excel cells do not render as `NaN`

## Testing
- `pip install pandas openpyxl xlrd xlwt` *(fails: Could not find a version that satisfies the requirement pandas)*
- `PYTHONPATH=upstream/packages/markitdown/src pytest upstream/packages/markitdown/tests/test_excel_empty_cells.py -q` *(skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6892dc4533148330be16cc2a6f402877