### PR TITLE
Fix build file naming to match repository name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,18 +15,18 @@ jobs:
           - os: windows-latest
             platform: windows
             arch: x86
-            binary_name: ixv-util-markitdown.exe
-            asset_name: ixv-util-markitdown-windows-x86.exe
+            binary_name: IXV-util-MarkItDown.exe
+            asset_name: IXV-util-MarkItDown-windows-x86.exe
           - os: macos-13
             platform: macos
             arch: x86
-            binary_name: ixv-util-markitdown
-            asset_name: ixv-util-markitdown-macos-x86
+            binary_name: IXV-util-MarkItDown
+            asset_name: IXV-util-MarkItDown-macos-x86
           - os: macos-latest
             platform: macos
             arch: arm64
-            binary_name: ixv-util-markitdown
-            asset_name: ixv-util-markitdown-macos-arm64
+            binary_name: IXV-util-MarkItDown
+            asset_name: IXV-util-MarkItDown-macos-arm64
 
     steps:
       - name: Checkout code
@@ -47,7 +47,7 @@ jobs:
       - name: Build binary with PyInstaller
         run: |
           if [ "${{ matrix.platform }}" = "windows" ]; then
-            uv run pyinstaller --onefile wrapper.py --name ixv-util-markitdown.exe
+            uv run pyinstaller --onefile wrapper.py --name IXV-util-MarkItDown.exe
           else
             uv run pyinstaller scripts/IXV-util-MarkItDown-mac.spec
           fi
@@ -64,9 +64,9 @@ jobs:
         run: |
           cd dist
           if [ "${{ matrix.platform }}" = "windows" ]; then
-            mv ixv-util-markitdown.exe ${{ matrix.asset_name }}
+            mv IXV-util-MarkItDown.exe ${{ matrix.asset_name }}
           else
-            mv ixv-util-markitdown ${{ matrix.asset_name }}
+            mv IXV-util-MarkItDown ${{ matrix.asset_name }}
           fi
 
       - name: Upload build artifact
@@ -123,9 +123,9 @@ jobs:
 
             ## ダウンロード
 
-            - **Windows (x86)**: `ixv-util-markitdown-windows-x86.exe`
-            - **macOS (x86)**: `ixv-util-markitdown-macos-x86`
-            - **macOS (ARM64)**: `ixv-util-markitdown-macos-arm64`
+            - **Windows (x86)**: `IXV-util-MarkItDown-windows-x86.exe`
+            - **macOS (x86)**: `IXV-util-MarkItDown-macos-x86`
+            - **macOS (ARM64)**: `IXV-util-MarkItDown-macos-arm64`
 
             ${{ steps.readme_content.outputs.USAGE_CONTENT }}
 
@@ -144,8 +144,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/ixv-util-markitdown-windows-x86.exe/ixv-util-markitdown-windows-x86.exe
-          asset_name: ixv-util-markitdown-windows-x86.exe
+          asset_path: artifacts/IXV-util-MarkItDown-windows-x86.exe/IXV-util-MarkItDown-windows-x86.exe
+          asset_name: IXV-util-MarkItDown-windows-x86.exe
           asset_content_type: application/octet-stream
 
       - name: Upload macOS x86 binary
@@ -154,8 +154,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/ixv-util-markitdown-macos-x86/ixv-util-markitdown-macos-x86
-          asset_name: ixv-util-markitdown-macos-x86
+          asset_path: artifacts/IXV-util-MarkItDown-macos-x86/IXV-util-MarkItDown-macos-x86
+          asset_name: IXV-util-MarkItDown-macos-x86
           asset_content_type: application/octet-stream
 
       - name: Upload macOS ARM64 binary
@@ -164,6 +164,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/ixv-util-markitdown-macos-arm64/ixv-util-markitdown-macos-arm64
-          asset_name: ixv-util-markitdown-macos-arm64
+          asset_path: artifacts/IXV-util-MarkItDown-macos-arm64/IXV-util-MarkItDown-macos-arm64
+          asset_name: IXV-util-MarkItDown-macos-arm64
           asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ NoMarkItDown モードは `.docx` のみ対応です。
 
 [Releases](https://github.com/elvezjp/IXV-util-MarkItDown/releases) からお使いの環境にあった最新版の実行ファイルをダウンロードしてください。
 
-- **Windows (x86)**: `ixv-util-markitdown-windows-x86.exe`
-- **macOS (x86)**: `ixv-util-markitdown-macos-x86`
-- **macOS (ARM64)**: `ixv-util-markitdown-macos-arm64`
+- **Windows (x86)**: `IXV-util-MarkItDown-windows-x86.exe`
+- **macOS (x86)**: `IXV-util-MarkItDown-macos-x86`
+- **macOS (ARM64)**: `IXV-util-MarkItDown-macos-arm64`
 
 ## 使い方
 
@@ -94,39 +94,39 @@ NoMarkItDown モードは `.docx` のみ対応です。
 
 ```bash
 # 単一ファイル変換
-ixv-util-markitdown.exe input.docx
+IXV-util-MarkItDown.exe input.docx
 
 # 複数ファイル一括変換
-ixv-util-markitdown.exe *.docx
+IXV-util-MarkItDown.exe *.docx
 
 # 出力先のディレクトリを指定
-ixv-util-markitdown.exe inputs/*.docx -d outputs
+IXV-util-MarkItDown.exe inputs/*.docx -d outputs
 
 # 変換オプション一覧
-ixv-util-markitdown.exe --help
+IXV-util-MarkItDown.exe --help
 ```
 
 ### macOS
 
 ```bash
 # 実行権限を付与（初回のみ）
-chmod +x ixv-util-markitdown
+chmod +x IXV-util-MarkItDown
 
 # macOSでは初回実行時にセキュリティダイアログが表示される場合があります。
 #「システム設定」→「プライバシーとセキュリティ」から実行を許可してください。
 # 再度実行時に「このまま開く」を選択してください。
 
 # 単一ファイル変換
-./ixv-util-markitdown input.docx
+./IXV-util-MarkItDown input.docx
 
 # 複数ファイル一括変換
-./ixv-util-markitdown *.docx
+./IXV-util-MarkItDown *.docx
 
 # 出力先のディレクトリを指定
-./ixv-util-markitdown inputs/*.docx -d outputs
+./IXV-util-MarkItDown inputs/*.docx -d outputs
 
 # 変換オプション一覧
-./ixv-util-markitdown --help
+./IXV-util-MarkItDown --help
 ```
 
 #### 注意事項
@@ -146,10 +146,10 @@ macOSでは**初回実行時にセキュリティダイアログが表示**さ�
 
 ```bash
 # MarkItDown モードで実行
-ixv-util-markitdown input.docx --mode markitdown
+IXV-util-MarkItDown input.docx --mode markitdown
 
 # NoMarkItDown モードで実行
-ixv-util-markitdown input.docx --mode nomarkitdown
+IXV-util-MarkItDown input.docx --mode nomarkitdown
 ```
 
 ### コマンドオプション
@@ -168,7 +168,7 @@ ixv-util-markitdown input.docx --mode nomarkitdown
 #### 1. 画像ファイル保存モード（デフォルト）
 ```bash
 # 画像を個別ファイルとして保存（推奨）
-ixv-util-markitdown document.docx -o output.md
+IXV-util-MarkItDown document.docx -o output.md
 ```
 
 - 画像は `images/` ディレクトリに保存されます
@@ -179,7 +179,7 @@ ixv-util-markitdown document.docx -o output.md
 #### 2. base64埋め込みモード
 ```bash
 # 画像をbase64データとしてマークダウンに埋め込み
-ixv-util-markitdown document.docx -o output.md --no-save-images
+IXV-util-MarkItDown document.docx -o output.md --no-save-images
 ```
 
 - 画像データがbase64形式でマークダウンに直接埋め込まれます
@@ -189,7 +189,7 @@ ixv-util-markitdown document.docx -o output.md --no-save-images
 #### 複数ファイル処理時の画像管理
 ```bash
 # 複数ファイルを一括変換
-ixv-util-markitdown *.docx -d outputs
+IXV-util-MarkItDown *.docx -d outputs
 ```
 
 各ファイルにファイル名がプレフィックスとして付与されるため、画像ファイル名の競合は発生しません：
@@ -236,10 +236,10 @@ uv pip install -e .
 uv sync
 
 # ビルド実行
-pyinstaller --onefile wrapper.py --name ixv-util-markitdown.exe
+pyinstaller --onefile wrapper.py --name IXV-util-MarkItDown.exe
 ```
 
-- 出力：`dist/ixv-util-markitdown.exe`
+- 出力：`dist/IXV-util-MarkItDown.exe`
 
 ### macOS 用単一実行ファイルのビルド
 
@@ -251,7 +251,7 @@ uv sync
 uv run pyinstaller scripts/IXV-util-MarkItDown-mac.spec
 ```
 
-- 出力：`dist/ixv-util-markitdown`
+- 出力：`dist/IXV-util-MarkItDown`
 - 注意：markitdownライブラリの依存関係を適切に同梱するため、必ず`scripts/IXV-util-MarkItDown-mac.spec`を使用してください
 
 ---

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ NoMarkItDown モードは `.docx` のみ対応です。
 [Releases](https://github.com/elvezjp/IXV-util-MarkItDown/releases) からお使いの環境にあった最新版の実行ファイルをダウンロードしてください。
 
 - **Windows (x86)**: `IXV-util-MarkItDown-windows-x86.exe`
-- **macOS (x86)**: `IXV-util-MarkItDown-macos-x86`
-- **macOS (ARM64)**: `IXV-util-MarkItDown-macos-arm64`
+- **macOS (Intel)**: `IXV-util-MarkItDown-macos-x86`
+- **macOS (Apple Silicon)**: `IXV-util-MarkItDown-macos-arm64`
 
 ## 使い方
 
@@ -94,39 +94,64 @@ NoMarkItDown モードは `.docx` のみ対応です。
 
 ```bash
 # 単一ファイル変換
-IXV-util-MarkItDown.exe input.docx
+IXV-util-MarkItDown-windows-x86.exe input.docx
 
 # 複数ファイル一括変換
-IXV-util-MarkItDown.exe *.docx
+IXV-util-MarkItDown-windows-x86.exe *.docx
 
 # 出力先のディレクトリを指定
-IXV-util-MarkItDown.exe inputs/*.docx -d outputs
+IXV-util-MarkItDown-windows-x86.exe inputs/*.docx -d outputs
 
 # 変換オプション一覧
-IXV-util-MarkItDown.exe --help
+IXV-util-MarkItDown-windows-x86.exe --help
 ```
 
 ### macOS
 
+#### macOS (Intel)
+
 ```bash
 # 実行権限を付与（初回のみ）
-chmod +x IXV-util-MarkItDown
+chmod +x IXV-util-MarkItDown-macos-x86
 
 # macOSでは初回実行時にセキュリティダイアログが表示される場合があります。
 #「システム設定」→「プライバシーとセキュリティ」から実行を許可してください。
 # 再度実行時に「このまま開く」を選択してください。
 
 # 単一ファイル変換
-./IXV-util-MarkItDown input.docx
+./IXV-util-MarkItDown-macos-x86 input.docx
 
 # 複数ファイル一括変換
-./IXV-util-MarkItDown *.docx
+./IXV-util-MarkItDown-macos-x86 *.docx
 
 # 出力先のディレクトリを指定
-./IXV-util-MarkItDown inputs/*.docx -d outputs
+./IXV-util-MarkItDown-macos-x86 inputs/*.docx -d outputs
 
 # 変換オプション一覧
-./IXV-util-MarkItDown --help
+./IXV-util-MarkItDown-macos-x86 --help
+```
+
+#### macOS (Apple Silicon)
+
+```bash
+# 実行権限を付与（初回のみ）
+chmod +x IXV-util-MarkItDown-macos-arm64
+
+# macOSでは初回実行時にセキュリティダイアログが表示される場合があります。
+#「システム設定」→「プライバシーとセキュリティ」から実行を許可してください。
+# 再度実行時に「このまま開く」を選択してください。
+
+# 単一ファイル変換
+./IXV-util-MarkItDown-macos-arm64 input.docx
+
+# 複数ファイル一括変換
+./IXV-util-MarkItDown-macos-arm64 *.docx
+
+# 出力先のディレクトリを指定
+./IXV-util-MarkItDown-macos-arm64 inputs/*.docx -d outputs
+
+# 変換オプション一覧
+./IXV-util-MarkItDown-macos-arm64 --help
 ```
 
 #### 注意事項
@@ -145,11 +170,17 @@ macOSでは**初回実行時にセキュリティダイアログが表示**さ�
 `--mode` オプションを指定するとモード選択のプロンプトをスキップできます。
 
 ```bash
-# MarkItDown モードで実行
-IXV-util-MarkItDown input.docx --mode markitdown
+# Windowsの例
+IXV-util-MarkItDown-windows-x86.exe input.docx --mode markitdown
+IXV-util-MarkItDown-windows-x86.exe input.docx --mode nomarkitdown
 
-# NoMarkItDown モードで実行
-IXV-util-MarkItDown input.docx --mode nomarkitdown
+# macOS (Intel)の例
+./IXV-util-MarkItDown-macos-x86 input.docx --mode markitdown
+./IXV-util-MarkItDown-macos-x86 input.docx --mode nomarkitdown
+
+# macOS (Apple Silicon)の例
+./IXV-util-MarkItDown-macos-arm64 input.docx --mode markitdown
+./IXV-util-MarkItDown-macos-arm64 input.docx --mode nomarkitdown
 ```
 
 ### コマンドオプション

--- a/README_en.md
+++ b/README_en.md
@@ -81,8 +81,8 @@ NoMarkItDown mode only supports `.docx` files.
 Download the latest executable file for your environment from [Releases](https://github.com/elvezjp/IXV-util-MarkItDown/releases).
 
 - **Windows (x86)**: `IXV-util-MarkItDown-windows-x86.exe`
-- **macOS (x86)**: `IXV-util-MarkItDown-macos-x86`
-- **macOS (ARM64)**: `IXV-util-MarkItDown-macos-arm64`
+- **macOS (Intel)**: `IXV-util-MarkItDown-macos-x86`
+- **macOS (Apple Silicon)**: `IXV-util-MarkItDown-macos-arm64`
 
 ---
 
@@ -96,39 +96,64 @@ Download the latest executable file for your environment from [Releases](https:/
 
 ```bash
 # Convert a single file
-IXV-util-MarkItDown.exe input.docx
+IXV-util-MarkItDown-windows-x86.exe input.docx
 
 # Batch convert multiple files
-IXV-util-MarkItDown.exe *.docx
+IXV-util-MarkItDown-windows-x86.exe *.docx
 
 # Specify output directory
-IXV-util-MarkItDown.exe inputs/*.docx -d outputs
+IXV-util-MarkItDown-windows-x86.exe inputs/*.docx -d outputs
 
 # List conversion options
-IXV-util-MarkItDown.exe --help
+IXV-util-MarkItDown-windows-x86.exe --help
 ```
 
 ### macOS
 
+#### macOS (Intel)
+
 ```bash
 # Grant execute permissions (first time only)
-chmod +x IXV-util-MarkItDown
+chmod +x IXV-util-MarkItDown-macos-x86
 
 # macOS may display security dialogs on first run.
 # Grant permission through "System Settings" → "Privacy & Security".
 # Select "Open" when running again.
 
 # Convert a single file
-./IXV-util-MarkItDown input.docx
+./IXV-util-MarkItDown-macos-x86 input.docx
 
 # Batch convert multiple files
-./IXV-util-MarkItDown *.docx
+./IXV-util-MarkItDown-macos-x86 *.docx
 
 # Specify output directory
-./IXV-util-MarkItDown inputs/*.docx -d outputs
+./IXV-util-MarkItDown-macos-x86 inputs/*.docx -d outputs
 
 # List conversion options
-./IXV-util-MarkItDown --help
+./IXV-util-MarkItDown-macos-x86 --help
+```
+
+#### macOS (Apple Silicon)
+
+```bash
+# Grant execute permissions (first time only)
+chmod +x IXV-util-MarkItDown-macos-arm64
+
+# macOS may display security dialogs on first run.
+# Grant permission through "System Settings" → "Privacy & Security".
+# Select "Open" when running again.
+
+# Convert a single file
+./IXV-util-MarkItDown-macos-arm64 input.docx
+
+# Batch convert multiple files
+./IXV-util-MarkItDown-macos-arm64 *.docx
+
+# Specify output directory
+./IXV-util-MarkItDown-macos-arm64 inputs/*.docx -d outputs
+
+# List conversion options
+./IXV-util-MarkItDown-macos-arm64 --help
 ```
 
 #### Important Notes
@@ -151,11 +176,17 @@ macOS may display **security dialogs on first run**.
 Use the `--mode` option to skip the mode selection prompt.
 
 ```bash
-# Run in MarkItDown mode
-IXV-util-MarkItDown input.docx --mode markitdown
+# Windows examples
+IXV-util-MarkItDown-windows-x86.exe input.docx --mode markitdown
+IXV-util-MarkItDown-windows-x86.exe input.docx --mode nomarkitdown
 
-# Run in NoMarkItDown mode
-IXV-util-MarkItDown input.docx --mode nomarkitdown
+# macOS (Intel) examples
+./IXV-util-MarkItDown-macos-x86 input.docx --mode markitdown
+./IXV-util-MarkItDown-macos-x86 input.docx --mode nomarkitdown
+
+# macOS (Apple Silicon) examples
+./IXV-util-MarkItDown-macos-arm64 input.docx --mode markitdown
+./IXV-util-MarkItDown-macos-arm64 input.docx --mode nomarkitdown
 ```
 
 ### Command Options

--- a/README_en.md
+++ b/README_en.md
@@ -80,9 +80,9 @@ NoMarkItDown mode only supports `.docx` files.
 
 Download the latest executable file for your environment from [Releases](https://github.com/elvezjp/IXV-util-MarkItDown/releases).
 
-- **Windows (x86)**: `ixv-util-markitdown-windows-x86.exe`
-- **macOS (x86)**: `ixv-util-markitdown-macos-x86`
-- **macOS (ARM64)**: `ixv-util-markitdown-macos-arm64`
+- **Windows (x86)**: `IXV-util-MarkItDown-windows-x86.exe`
+- **macOS (x86)**: `IXV-util-MarkItDown-macos-x86`
+- **macOS (ARM64)**: `IXV-util-MarkItDown-macos-arm64`
 
 ---
 
@@ -96,48 +96,48 @@ Download the latest executable file for your environment from [Releases](https:/
 
 ```bash
 # Convert a single file
-ixv-util-markitdown.exe input.docx
+IXV-util-MarkItDown.exe input.docx
 
 # Batch convert multiple files
-ixv-util-markitdown.exe *.docx
+IXV-util-MarkItDown.exe *.docx
 
 # Specify output directory
-ixv-util-markitdown.exe inputs/*.docx -d outputs
+IXV-util-MarkItDown.exe inputs/*.docx -d outputs
 
 # List conversion options
-ixv-util-markitdown.exe --help
+IXV-util-MarkItDown.exe --help
 ```
 
 ### macOS
 
 ```bash
 # Grant execute permissions (first time only)
-chmod +x ixv-util-markitdown
+chmod +x IXV-util-MarkItDown
 
 # macOS may display security dialogs on first run.
 # Grant permission through "System Settings" → "Privacy & Security".
 # Select "Open" when running again.
 
 # Convert a single file
-./ixv-util-markitdown input.docx
+./IXV-util-MarkItDown input.docx
 
 # Batch convert multiple files
-./ixv-util-markitdown *.docx
+./IXV-util-MarkItDown *.docx
 
 # Specify output directory
-./ixv-util-markitdown inputs/*.docx -d outputs
+./IXV-util-MarkItDown inputs/*.docx -d outputs
 
 # List conversion options
-./ixv-util-markitdown --help
+./IXV-util-MarkItDown --help
 ```
 
 #### Important Notes
 
 macOS may display **security dialogs on first run**.
 
-1. If you see a dialog saying '"ixv-util-markitdown" cannot be opened because the developer cannot be verified':
+1. If you see a dialog saying '"IXV-util-MarkItDown" cannot be opened because the developer cannot be verified':
    - Open "System Settings" → "Privacy & Security"
-   - In the Security section, find '"ixv-util-markitdown" was blocked from use because it is not from an identified developer' and click "Allow Anyway"
+   - In the Security section, find '"IXV-util-MarkItDown" was blocked from use because it is not from an identified developer' and click "Allow Anyway"
    - Enter your password to confirm
 
 2. If you see a "cannot verify the developer" dialog when running again:
@@ -152,10 +152,10 @@ Use the `--mode` option to skip the mode selection prompt.
 
 ```bash
 # Run in MarkItDown mode
-ixv-util-markitdown input.docx --mode markitdown
+IXV-util-MarkItDown input.docx --mode markitdown
 
 # Run in NoMarkItDown mode
-ixv-util-markitdown input.docx --mode nomarkitdown
+IXV-util-MarkItDown input.docx --mode nomarkitdown
 ```
 
 ### Command Options
@@ -174,7 +174,7 @@ In **MarkItDown mode**, images contained in documents can be processed in two wa
 #### 1. Image File Saving Mode (Default)
 ```bash
 # Save images as separate files (recommended)
-ixv-util-markitdown document.docx -o output.md
+IXV-util-MarkItDown document.docx -o output.md
 ```
 
 - Images are saved to an `images/` directory
@@ -185,7 +185,7 @@ ixv-util-markitdown document.docx -o output.md
 #### 2. Base64 Embedding Mode
 ```bash
 # Embed images as base64 data in markdown
-ixv-util-markitdown document.docx -o output.md --no-save-images
+IXV-util-MarkItDown document.docx -o output.md --no-save-images
 ```
 
 - Image data is directly embedded in markdown as base64 format
@@ -195,7 +195,7 @@ ixv-util-markitdown document.docx -o output.md --no-save-images
 #### Image Management for Multiple Files
 ```bash
 # Batch convert multiple files
-ixv-util-markitdown *.docx -d outputs
+IXV-util-MarkItDown *.docx -d outputs
 ```
 
 Each file gets a filename prefix to prevent filename conflicts:
@@ -242,10 +242,10 @@ uv pip install -e .
 uv sync
 
 # Build
-pyinstaller --onefile wrapper.py --name ixv-util-markitdown.exe
+pyinstaller --onefile wrapper.py --name IXV-util-MarkItDown.exe
 ```
 
-- Output: `dist/ixv-util-markitdown.exe`
+- Output: `dist/IXV-util-MarkItDown.exe`
 
 ### Build single executable for macOS
 
@@ -257,7 +257,7 @@ uv sync
 uv run pyinstaller scripts/IXV-util-MarkItDown-mac.spec
 ```
 
-- Output: `dist/ixv-util-markitdown`
+- Output: `dist/IXV-util-MarkItDown`
 - Note: Always use `scripts/IXV-util-MarkItDown-mac.spec` to properly bundle the markitdown library dependencies
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [project.scripts]
-ixv-util-markitdown = "markitdown.cli:main"
+IXV-util-MarkItDown = "markitdown.cli:main"
 
 [build-system]
 requires = ["hatchling"]
@@ -44,6 +44,6 @@ console = true
 # macOS 単一実行ファイル作成用のPyInstaller設定
 entry-point = "wrapper.py"
 onefile = true
-name = "ixv-util-markitdown"
+name = "IXV-util-MarkItDown"
 console = true
 distpath = "./dist"

--- a/scripts/IXV-util-MarkItDown-mac.spec
+++ b/scripts/IXV-util-MarkItDown-mac.spec
@@ -49,7 +49,7 @@ exe = EXE(
     a.binaries,
     a.datas,
     [],
-    name='ixv-util-markitdown',
+    name='IXV-util-MarkItDown',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,


### PR DESCRIPTION
## Summary
• Changed build output file names from lowercase `ixv-util-markitdown` to proper case `IXV-util-MarkItDown` to match repository name
• Updated all references in pyproject.toml, build scripts, GitHub Actions workflow, and documentation
• Separated macOS usage examples for Intel and Apple Silicon architectures

## Changes Made
- **pyproject.toml**: Updated project scripts and PyInstaller settings
- **scripts/IXV-util-MarkItDown-mac.spec**: Updated binary name
- **.github/workflows/release.yml**: Updated all binary names and asset names
- **README.md & README_en.md**: Updated download links and command examples with proper file names for each platform

## Test plan
- [ ] Verify build process generates correct file names
- [ ] Test that all command examples in README match actual download file names
- [ ] Confirm GitHub Actions workflow produces properly named artifacts

🤖 Generated with [Claude Code](https://claude.ai/code)